### PR TITLE
Refactor: move cachedRandomChance into single internal value in main

### DIFF
--- a/src/main/java/circuitlord/reactivemusic/ReactiveMusicCore.java
+++ b/src/main/java/circuitlord/reactivemusic/ReactiveMusicCore.java
@@ -38,6 +38,7 @@ public final class ReactiveMusicCore {
 	static int fadeOutTicks = 0;
 	static int silenceTicks = 0;
     static Random rand = new Random();
+    float randomChance  = rand.nextFloat();
 
     /**
      * This is the built-in logic for Reactive Music's song switcher.
@@ -202,7 +203,7 @@ public final class ReactiveMusicCore {
     
                 if (entry.shouldStopMusicOnInvalid()) {
                     ReactiveMusicDebug.LOGGER.info("trying forceStopMusicOnInvalid: " + entry.getEventString());
-                    if (entry.getCachedRandomChance() <= entry.getForceChance()) {
+                    if (randomChance  <= entry.getForceChance()) {
                         ReactiveMusicDebug.LOGGER.info("doing forceStopMusicOnInvalid: " + entry.getEventString());
                         queuedToStopMusic = true;
                     }
@@ -215,8 +216,7 @@ public final class ReactiveMusicCore {
     
             if (previousValidEntries.stream().noneMatch(e -> java.util.Objects.equals(e.getEventString(), entry.getEventString()))) {
                 // use the same random chance for all so they always happen together
-                entry.setCachedRandomChance(rand.nextFloat());
-                boolean randSuccess = entry.getCachedRandomChance() <= entry.getForceChance();
+                boolean randSuccess = randomChance <= entry.getForceChance();
     
                 // if this event wasn't valid before and is now
                 ReactiveMusicDebug.LOGGER.info("Triggering onValid() for songpack event plugins");

--- a/src/main/java/circuitlord/reactivemusic/api/songpack/RuntimeEntry.java
+++ b/src/main/java/circuitlord/reactivemusic/api/songpack/RuntimeEntry.java
@@ -29,13 +29,6 @@ public interface RuntimeEntry {
     float getForceChance();
     
     List<RMEntryCondition> getConditions();
-    
-    /***************************************************************
-     * TODO: These should be removed and refactored ⚠️
-     * all of the entries use the same random number internally
-     * so there is no reason to hold it within the entry
-     */
-    @Deprecated float getCachedRandomChance();
-    @Deprecated void setCachedRandomChance(float c);
+   
     
 }

--- a/src/main/java/circuitlord/reactivemusic/impl/songpack/RMRuntimeEntry.java
+++ b/src/main/java/circuitlord/reactivemusic/impl/songpack/RMRuntimeEntry.java
@@ -30,9 +30,7 @@ public class RMRuntimeEntry implements RuntimeEntry {
     
     public String eventString = "";
     public String errorString = "";
-    
-    public float cachedRandomChance = 1.0f;
-    
+        
     public HashMap<String, Object> entryMap = new HashMap<>();
     
     public Object getExternalOption(String key) {
@@ -75,8 +73,6 @@ public class RMRuntimeEntry implements RuntimeEntry {
     public boolean shouldStopMusicOnValid() { return forceStopMusicOnValid; }
     public boolean shouldStopMusicOnInvalid() { return forceStopMusicOnInvalid; }
     public boolean shouldStartMusicOnValid() { return forceStartMusicOnValid; }
-    public float getCachedRandomChance() { return cachedRandomChance; }
-    public void setCachedRandomChance(float c) { cachedRandomChance = c; }
     public String getSongpack() { return songpack; }
     public List<RMEntryCondition> getConditions() { return conditions; }
 


### PR DESCRIPTION
I refactored cachedRandomChance to be calculated only once in the main flow.